### PR TITLE
Avoid Spec Top & Bottom Bar to move Spec TargetID

### DIFF
--- a/resource/ui/spectator.res
+++ b/resource/ui/spectator.res
@@ -166,8 +166,7 @@
 	{
 		"ControlName"		"Panel"
 		"fieldName"		"TopBar"
-		"xpos"		"9999"
-		"tall"		"0"
+		"ypos"		"r0"
 		"wide"		"0"
 		"enabled"		"0"
 	}
@@ -175,7 +174,7 @@
 	{
 		"ControlName"		"Frame"
 		"fieldName"		"BottomBar"
-		"xpos"		"9999"
+		"ypos"		"r0"
 		"wide"		"0"
 		"enabled"		"0"
 	}
@@ -183,7 +182,7 @@
 	{
 		"ControlName"		"Panel"
 		"fieldName"		"bottombarblank"
-		"xpos"		"9999"
+		"ypos"		"r0"
 		"wide"		"0"
 		"enabled"		"0"
 	}


### PR DESCRIPTION
So basically when editing my crossover hud, found out that doing TopBar and BottomBlank to xpos 9999, it made the TargetID (when appears when spectate) totally dissappear.