### PR TITLE
Fix MatchSummary bg

### DIFF
--- a/resource/ui/hudmatchsummary.res
+++ b/resource/ui/hudmatchsummary.res
@@ -122,7 +122,6 @@
 		"tall"		"f0"
 		"visible"		"0"
 		"enabled"		"1"
-		"PaintBackgroundType"	"1"
 		"bgcolor_override" "0 0 0 250"
 	}
 


### PR DESCRIPTION
Fixes this weird texture that's behind the match summary.
![tf_win64 exe Screenshot 2024 11 06 - 13 33 38 36](https://github.com/user-attachments/assets/074c5d13-9b3b-4802-ba4e-01d109aa507d)
