### PR TITLE
Fix Dimmer Reload

### DIFF
--- a/cfg/xhud.cfg
+++ b/cfg/xhud.cfg
@@ -308,10 +308,9 @@ tf_mvm_tabs_discovered 1
 tf_matchmaking_ticket_help 1
 tf_mvm_classupgradehelpcount 3	//Disable tutorials end
 
-testhudanim DashboardDimmerReload	//Apply dashboard dimmer settings
-
 //Load customizations to memory
-sv_cheats 1;sv_allow_wait_command 1;wait 100;
+sv_cheats 1;sv_allow_wait_command 1;testhudanim DashboardDimmerReload
+
 echo;echo
 echo =====================
 echo Xhud Settings Loading

--- a/scripts/hudanimations_x.txt
+++ b/scripts/hudanimations_x.txt
@@ -32,12 +32,18 @@ event HudTournament_MoveChatWindow
 
 event DashboardDimmerReload
 {
-	RunEventChild MainMenuOverride ReloadHUD 0.001
+    RunEventChild MainMenuOverride FixDimmer 0
 }
 
-event ReloadHUD
+event FixDimmer
 {
-	FireCommand 0.0 "engine hud_reloadscheme"
+    RunEventChild MMDashboard LoadDimmer 0.001
+    FireCommand 0.003 "engine hud_reloadscheme"
+}
+
+event LoadDimmer
+{
+    FireCommand 0 "dimmer_clicked"
 }
 
 //==============================================================================

--- a/scripts/hudanimations_x.txt
+++ b/scripts/hudanimations_x.txt
@@ -32,18 +32,18 @@ event HudTournament_MoveChatWindow
 
 event DashboardDimmerReload
 {
-    RunEventChild MainMenuOverride FixDimmer 0
+	RunEventChild MainMenuOverride FixDimmer 0
 }
 
 event FixDimmer
 {
-    RunEventChild MMDashboard LoadDimmer 0.001
-    FireCommand 0.003 "engine hud_reloadscheme"
+	RunEventChild MMDashboard LoadDimmer 0.001
+	FireCommand 0.003 "engine hud_reloadscheme"
 }
 
 event LoadDimmer
 {
-    FireCommand 0 "dimmer_clicked"
+	FireCommand 0 "dimmer_clicked"
 }
 
 //==============================================================================


### PR DESCRIPTION
This just makes the dimmer reloading functional, it doesn't fix the issue of it not applying to +connect launch options

I removed the wait command because commands in cfg files are executed in parallel so it wasn't doing anything, you can test this by having 2 echo commands before and after the wait command and see that they get shown at the exact same time.
Timings were tested on 59 fps and 1000+ fps, these were the lowest I could get them and have them still work.